### PR TITLE
Update version to match gem version

### DIFF
--- a/lib/zip-codes.rb
+++ b/lib/zip-codes.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 
 module ZipCodes
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 
   class << self
     def identify code


### PR DESCRIPTION
The version should match the gem version... but then by updating this you'd need to re-issue the gem...

Either way, at least the code will match the existing gem.