### PR TITLE
Add update task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,33 @@ require 'yaml'
 task :convert do
   codes = {}
   File.open('lib/data/US.txt').each_line do |line|
-    array = line.split('\t')
+    array = line.split("\t")
     codes[array[1]] = {
       state_code: array[4],
       state_name: array[3],
       city: array[2]
     }
+  end
+
+  File.write('lib/data/US.yml', codes.to_yaml)
+end
+
+task :update do
+  path = File.join(__dir__, 'lib', 'data', 'US.yml')
+  codes = ::YAML.safe_load_file(path, permitted_classes: [Symbol])
+
+  # Data comes from https://download.geonames.org/export/zip/
+  File.open('lib/data/US.txt').each_line do |line|
+    array = line.split("\t")
+
+    # Only add codes that are not in the list already and that parse out a state code
+    if codes[array[1]].nil? && array[4] != ''
+      codes[array[1]] = {
+        state_code: array[4],
+        state_name: array[3],
+        city: array[2]
+      }
+    end
   end
 
   File.write('lib/data/US.yml', codes.to_yaml)


### PR DESCRIPTION
We keep running into missing zip codes and I noticed the list of PRs to manually add things one at a time seems like a lot of maintainer overhead.

This task lets you download the latest upstream file and incorporate all new zip codes in one shot.  This could be extended to also download the upstream file automatically, but I did not include that because I wanted to mirror the behavior of the existing rake task.  If you'd like me to add that I'm happy to.

Whether we can get this merged or not, though, it'd be great if we could cut a new gem version that includes all the added zip codes.

Thanks!  This gem has been tremendously useful for us.